### PR TITLE
It is better to use the repository field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sozu-client"
-homepage = "https://github.com/CleverCloud/sozu-client"
+repository = "https://github.com/CleverCloud/sozu-client"
 description = "This library provides a client to interact with Sōzu."
 documentation = "https://github.com/CleverCloud/sozu-client/blob/main/README.md"
 version = "0.4.0"


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.