### PR TITLE
ci(github): scheduled cargo audit + remove dead code

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,32 @@
+---
+name: Security audit
+on:
+  push:
+    paths:
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
+  pull_request:
+    paths:
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
+  schedule:
+    # Run weekly so newly-disclosed advisories are caught even without code changes.
+    - cron: "0 6 * * 1"
+  # Allow running the audit on demand from the Actions tab.
+  workflow_dispatch:
+jobs:
+  audit:
+    name: cargo audit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+      - name: Install cargo-audit
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-audit
+      - name: Generate lockfile
+        # Cargo.lock is gitignored for this library, so resolve one to audit.
+        run: cargo generate-lockfile
+      - name: Audit dependencies
+        run: cargo audit

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -61,17 +61,6 @@ impl TryFrom<&PathBuf> for ConnectionProperties {
     }
 }
 
-impl ConnectionProperties {
-    #[tracing::instrument]
-    fn new(socket: PathBuf, buffer_size: u64, max_buffer_size: u64) -> Self {
-        Self {
-            socket,
-            buffer_size,
-            max_buffer_size,
-        }
-    }
-}
-
 // -----------------------------------------------------------------------------
 // ConnectionManager
 


### PR DESCRIPTION
Small post-v0.5.0 follow-ups.

### 1. Scheduled security audit (`.github/workflows/audit.yml`)
Adds a RustSec advisory scan that runs **weekly** (cron) and on any `Cargo.toml`/`Cargo.lock` change. Since `Cargo.lock` is gitignored for this library, the job resolves one with `cargo generate-lockfile` before running `cargo audit`. Uses maintained actions (`actions/checkout@v4`, `taiki-e/install-action`) because `actions-rs/*` is deprecated.

### 2. Remove dead `ConnectionProperties::new` (`src/channel.rs`)
The private constructor was never called (`ConnectionProperties` is built via `From<&Config>` / `TryFrom<&PathBuf>`) and produced a `dead_code` warning. Removing it makes `cargo clippy --all-features` warning-free.

### Validation (Rust 1.88.0)
- `cargo clippy --all-features` → **No issues found** (previously 1 warning)
- `cargo build --all-features` + `cargo fmt --check` clean
- `audit.yml` is valid YAML; the audit job logic ran locally (192 deps scanned, **0 advisories**)